### PR TITLE
[GCO-770] Fixed bug with work-around

### DIFF
--- a/config/model/endpoint.trig
+++ b/config/model/endpoint.trig
@@ -42,8 +42,10 @@ GRAPH config:Theatre {
   config:ResourceRepresentation a elmo:Representation;
     elmo:stage config:Stage;
     elmo:contains config:Menu;
+    elmo:contains config:Parameters;
     elmo:appliesTo "http://dbpedia.org/resource/{reference}";
     elmo:informationProduct config:DbpediaData;
+    elmo:parameterMapper config:SubjectFromUrl; #Endpoint mapper should be sufficient, but doesn't work!
   .
 
   #Information Product
@@ -66,5 +68,23 @@ GRAPH config:Theatre {
       }
     """;
   .
+
+#Sub Representation
+config:Parameters a elmo:Representation;
+  elmo:stage config:Stage;
+  elmo:informationProduct config:ParametersData
+.
+#Sub information product (check for parameter mapper)
+config:ParametersData a elmo:InformationProduct;
+  elmo:backend config:DBPediaBackend;
+  elmo:requiredParameter elmo:SubjectParameter;
+  elmo:query """
+    CONSTRUCT {
+      <urn:value> rdf:subject "?subject".
+      <urn:value> rdf:subject ?subject
+    }
+    WHERE {}
+  """
+.
 
 }

--- a/src/main/java/org/dotwebstack/ldtlegacy/CreatePage.java
+++ b/src/main/java/org/dotwebstack/ldtlegacy/CreatePage.java
@@ -91,7 +91,7 @@ public class CreatePage {
       }
       configMerger.finishMerging();
       //Translate to elmo1 vocabulary configuration
-      StartTerminal configPipe1 = new StartTerminal(
+      final StartTerminal configPipe1 = new StartTerminal(
           null,
           new ByteArrayInputStream(appearanceData.toByteArray())) {
         @Override
@@ -108,6 +108,9 @@ public class CreatePage {
           parameterValues.put(name, value.get(0));
         }
       });
+      // add parameter values from mappers (only top representation)
+      representation.getParameterMappers().forEach(
+          parameterMapper -> parameterValues.putAll(parameterMapper.map(containerRequestContext)));
       //Merge configuration result with context (empty at this moment)
       Context context = new Context(containerRequestContext, linkstrategy,
           representation.getStage(), parameterValues);

--- a/src/main/java/org/dotwebstack/ldtlegacy/FrameworkGhost.java
+++ b/src/main/java/org/dotwebstack/ldtlegacy/FrameworkGhost.java
@@ -22,19 +22,9 @@ import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriter;
 
 public class FrameworkGhost {
 
-  public static Object fetchInformationProductData(Representation representation,
-                                                   Map<String, String> parameterValues,
-                                                   ContainerRequestContext context) {
-    representation.getParameterMappers().forEach(parameterMapper ->
-        parameterValues.putAll(parameterMapper.map(context)));
-    return representation.getInformationProduct().getResult(parameterValues);
-  }
-
   public static void getXml(Representation representation, Map<String, String> parameterValues,
                             OutputStream outputStream,
                             ContainerRequestContext containerRequestContext) {
-    representation.getParameterMappers().forEach(
-        parameterMapper -> parameterValues.putAll(parameterMapper.map(containerRequestContext)));
     Object result = representation.getInformationProduct().getResult(parameterValues);
     if (result instanceof GraphQueryResult) {
       QueryResults.report((GraphQueryResult) result, new RDFXMLWriter(outputStream));


### PR DESCRIPTION
Problem: subrepresentations won't get mapped values from parametermapper.

Solution: solved, by adding parametermapper to representation

This is a work-around, because the parametermapper is already available at the endpoint. However, the endpoint is not available, only the representation is available!